### PR TITLE
Remove reference to standalone cobra cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init:
 	ln -s ../../githooks/pre-push .git/hooks/pre-push
 	ln -s ../../githooks/pre-commit .git/hooks/pre-commit
 	go get github.com/samuel/go-thrift/parser
-	go get github.com/spf13/cobra/cobra
+	go get github.com/spf13/cobra
 	go get github.com/jteeuwen/go-bindata/...
 
 test: buildTpl


### PR DESCRIPTION
Switches the go get command to use the cobra library instead of the cobra/cobra command, since the command is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)